### PR TITLE
Fixed FDC issue

### DIFF
--- a/rtl/FDC/FDCs.vhd
+++ b/rtl/FDC/FDCs.vhd
@@ -1080,7 +1080,7 @@ begin
 						RD_CMD<='1';
 						sDIOc<='1';
 						if(SISen='1')then
-							RDDAT_CMD<=ST0;
+							RDDAT_CMD<=(ST0 and x"FB");
 							SEclr<='1';
 							datnum<=datnum+1;
 						else


### PR DESCRIPTION
I found a solution to the issue where some games cannot boot.
FDC doesn't respond to the SEEK commands as these drivers expect.

With this modification, Ys can be booted.