### PR TITLE
Add mouse support

### DIFF
--- a/PC8801SR.sv
+++ b/PC8801SR.sv
@@ -218,6 +218,7 @@ parameter CONF_STR = {
 	"OB,Cols,80,40;",
 	"OC,Lines,25,20;",
 	"OD,Disk boot,Enable,Disable;",
+	"OK,Input,Joypad,Mouse;",
 	"-;",
 	"R6,Reset;",
 	"J,Fire 1,Fire 2;",
@@ -303,6 +304,7 @@ wire  [3:0] img_readonly;
 wire [63:0] img_size;
 
 wire [65:0] ps2_key;
+wire [24:0] ps2_mouse;
 wire [64:0] sysrtc;
 wire [21:0] gamma_bus;
 wire  [7:0] uart1_mode;
@@ -343,12 +345,9 @@ hps_io #(.CONF_STR(CONF_STR), .PS2DIV(600), .PS2WE(1), .VDNUM(4)) hps_io
 	.ps2_kbd_data_out(ps2_kbd_data_out),
 	.ps2_kbd_clk_in(ps2_kbd_clk_in),
 	.ps2_kbd_data_in(ps2_kbd_data_in),
-	.ps2_mouse_clk_out(ps2_mouse_clk_out),
-	.ps2_mouse_data_out(ps2_mouse_data_out),
-	.ps2_mouse_clk_in(ps2_mouse_clk_in),
-	.ps2_mouse_data_in(ps2_mouse_data_in),
 
 	.ps2_key(ps2_key),
+	.ps2_mouse(ps2_mouse),
 	
 	.RTC(sysrtc),
 
@@ -377,6 +376,7 @@ wire	c20L	=status[12];
 wire	cDisk	=status[13];
 wire	MTSAVE	=1;
 wire [1:0]FDsync=status[16:15];
+wire	cInDev	=status[20];
 
 assign CLK_VIDEO = clk_ram;
 assign AUDIO_S = 1;
@@ -419,10 +419,7 @@ PC88MiSTer PC88_top
 	.pPs2Datin(ps2_kbd_data_out),
 	.pPs2Datout(ps2_kbd_data_in),
 
-	.pPmsClkin(ps2_mouse_clk_out),
-	.pPmsClkout(ps2_mouse_clk_in),
-	.pPmsDatin(ps2_mouse_data_out),
-	.pPmsDatout(ps2_mouse_data_in),
+	.ps2_mouse(ps2_mouse),
 
 	.pJoyA(joyA),
 	.pJoyB(joyB),
@@ -444,7 +441,7 @@ PC88MiSTer PC88_top
 	.pFd_sync(FDsync),
 
 	.pLed(disk_led),
-	.pDip({clkmode,2'b0,cDisk,c20L,c40C,MTSAVE,cBT,basicmode}),
+	.pDip({cInDev,clkmode,2'b0,cDisk,c20L,c40C,MTSAVE,cBT,basicmode}),
 	.pPsw(2'b11),
 
 	.pVideoR(red),

--- a/files.qip
+++ b/files.qip
@@ -150,5 +150,6 @@ set_global_assignment -name VHDL_FILE rtl/FDtiming.vhd
 set_global_assignment -name VHDL_FILE rtl/IO_DETAC.vhd
 set_global_assignment -name VHDL_FILE rtl/FECcont.vhd
 set_global_assignment -name VHDL_FILE rtl/trammaps.vhd
+set_global_assignment -name VERILOG_FILE rtl/ps2mouse.v
 set_global_assignment -name VHDL_FILE rtl/PC88MiSTer.vhd
 set_global_assignment -name SYSTEMVERILOG_FILE PC8801SR.sv

--- a/rtl/ps2mouse.v
+++ b/rtl/ps2mouse.v
@@ -1,0 +1,82 @@
+
+module ps2mouse
+(
+	input            clk,
+	input            reset,
+
+	input            strobe,
+	output reg [5:0] data,
+
+	input     [24:0] ps2_mouse
+);
+
+wire [11:0] mdx = {{4{ps2_mouse[4]}},ps2_mouse[15:8]};
+wire [11:0] mdy = {{4{ps2_mouse[5]}},ps2_mouse[23:16]};
+
+always @(posedge clk) begin
+	reg  [5:0] count;
+	reg        old_clk;
+	reg        old_strobe;
+	reg  [2:0] state = 0;
+	reg [14:0] timer = 0; //MSX mouse timer
+	reg  [7:0] mx;
+	reg  [7:0] my;
+	reg  [2:0] button;
+	reg [11:0] dx;
+	reg [11:0] dy;
+	reg        old_stb;
+
+	if(~&timer) timer <= timer + 1'b1;
+	old_strobe <= strobe;
+	
+	old_stb <= ps2_mouse[24];
+
+	if(reset) begin
+		dx     <= 0;
+		dy     <= 0;
+		data   <= 'b110000;
+		state  <= 0;
+	end
+	else begin
+		if(old_stb ^ ps2_mouse[24]) begin
+			data[5:4] <= ~ps2_mouse[1:0];
+			dx <= dx - mdx;
+			dy <= dy + mdy;
+		end
+
+		case(state)
+			0: if(~old_strobe && strobe && &timer) begin
+					state <= state + 1'd1;
+					mx    <= dx[8:1];
+					my    <= dy[8:1];
+					dx    <= 0;
+					dy    <= 0;
+					timer <= 0;
+
+					data[3:0] <= dx[7:4];
+				end
+
+			1: if(old_strobe && ~strobe) begin
+					state <= state + 1'd1;
+					data[3:0] <= mx[3:0];
+				end
+
+			2: if(~old_strobe && strobe) begin
+					state <= state + 1'd1;
+					data[3:0] <= my[7:4];
+				end
+
+			3: if(old_strobe && ~strobe) begin
+					state <= state + 1'd1;
+					data[3:0] <= my[3:0];
+				end
+
+			4: if(~old_strobe && strobe) begin
+					state <= 0;
+					data[3:0] <= 0;
+				end
+		endcase
+	end
+end
+
+endmodule

--- a/rtl/ps2mouse.v
+++ b/rtl/ps2mouse.v
@@ -1,7 +1,8 @@
-
+// Outputs input signals from a PS/2 mouse in the MSX mouse protocol
+// Besed on ps2mouse module in MiSTer MSX core
 module ps2mouse
 (
-	input            clk,
+	input            clk,	// 20MHz
 	input            reset,
 
 	input            strobe,
@@ -14,68 +15,75 @@ wire [11:0] mdx = {{4{ps2_mouse[4]}},ps2_mouse[15:8]};
 wire [11:0] mdy = {{4{ps2_mouse[5]}},ps2_mouse[23:16]};
 
 always @(posedge clk) begin
-	reg  [5:0] count;
-	reg        old_clk;
-	reg        old_strobe;
+	reg  [6:0] old_strobe;
 	reg  [2:0] state = 0;
-	reg [14:0] timer = 0; //MSX mouse timer
+	reg  [8:0] timer = 0;	// 20MHz / 512 = 25.6us
 	reg  [7:0] mx;
 	reg  [7:0] my;
-	reg  [2:0] button;
 	reg [11:0] dx;
 	reg [11:0] dy;
 	reg        old_stb;
 
-	if(~&timer) timer <= timer + 1'b1;
-	old_strobe <= strobe;
-	
 	old_stb <= ps2_mouse[24];
 
 	if(reset) begin
-		dx     <= 0;
-		dy     <= 0;
-		data   <= 'b110000;
-		state  <= 0;
+		dx     	<= 0;
+		dy     	<= 0;
+		data   	<= 'b110000;
+		state  	<= 0;
+		old_strobe	<= 7'b0000000;
+		timer	<= 0;
 	end
 	else begin
+		timer <= timer + 1'b1;
 		if(old_stb ^ ps2_mouse[24]) begin
 			data[5:4] <= ~ps2_mouse[1:0];
 			dx <= dx - mdx;
 			dy <= dy + mdy;
 		end
 
-		case(state)
-			0: if(~old_strobe && strobe && &timer) begin
-					state <= state + 1'd1;
-					mx    <= dx[8:1];
-					my    <= dy[8:1];
-					dx    <= 0;
-					dy    <= 0;
-					timer <= 0;
+		// sampling strobe every 25.6us
+		if (&timer) begin
+			old_strobe[6:1] <= old_strobe[5:0];
+			old_strobe[0] 	<= strobe;
 
-					data[3:0] <= dx[7:4];
-				end
+			if ({old_strobe,strobe} == 8'h0) begin
+				// reset: hold L over 200us 
+				state <= 0;
+			end else begin
+				case(state)
+				0: if(~old_strobe[1] && old_strobe[0] && strobe) begin
+					// first strobe: hold H over 50us
+						state <= state + 1'd1;
+						mx    <= dx[8:1];
+						my    <= dy[8:1];
+						dx    <= 0;
+						dy    <= 0;
+						data[3:0] <= dx[8:5];
+					end
 
-			1: if(old_strobe && ~strobe) begin
-					state <= state + 1'd1;
-					data[3:0] <= mx[3:0];
-				end
+				1: if(old_strobe[0] && ~strobe) begin
+						state <= state + 1'd1;
+						data[3:0] <= mx[3:0];
+					end
 
-			2: if(~old_strobe && strobe) begin
-					state <= state + 1'd1;
-					data[3:0] <= my[7:4];
-				end
+				2: if(~old_strobe[0] && strobe) begin
+						state <= state + 1'd1;
+						data[3:0] <= my[7:4];
+					end
 
-			3: if(old_strobe && ~strobe) begin
-					state <= state + 1'd1;
-					data[3:0] <= my[3:0];
-				end
+				3: if(old_strobe[0] && ~strobe) begin
+						state <= state + 1'd1;
+						data[3:0] <= my[3:0];
+					end
 
-			4: if(~old_strobe && strobe) begin
-					state <= 0;
-					data[3:0] <= 0;
-				end
-		endcase
+				4: if(~old_strobe[0] && strobe) begin
+						state <= 0;
+						data[3:0] <= 0;
+					end
+				endcase
+			end
+		end
 	end
 end
 


### PR DESCRIPTION
Supports PC-8872 compatible mouse. (aka "bus mouse")

To enable it, connect a USB mouse to MiSTer, and select "Mouse" in the "Input" of the F12 menu.
The mouse cannot be enabled at the same time as the joypad.
(default: Joypad)