### PR TITLE
Change LED indicators

### DIFF
--- a/PC8801SR.sv
+++ b/PC8801SR.sv
@@ -191,10 +191,9 @@ assign VGA_DISABLE = 0;
 assign UART_TXD = 0;
 
 //////////////////////////////////////////////////////////////////
-wire hdd_active = sd_rd[2] || sd_wr[2];
-wire fdd_active = |sd_rd[1:0] || |sd_wr[1:0];
-assign LED_USER  = fdd_active;
-assign LED_DISK  = {1'b1, hdd_active};
+wire mist_active = |sd_rd[2:0] || |sd_wr[2:0];
+assign LED_USER  = disk_led;
+assign LED_DISK  = {1'b0, mist_active};
 
 wire [1:0] ar = status[2:1];
 

--- a/rtl/PC88MiSTer.vhd
+++ b/rtl/PC88MiSTer.vhd
@@ -881,6 +881,7 @@ port(
 	
 	EMUINITDONE		:out std_logic;
 	EMUBUSY			:out std_logic;
+	FDCBUSY			:out std_logic;
 	CPUCLK			:in std_logic;
 	clk21m			:in std_logic;
 	ramclk			:in std_logic;
@@ -2229,7 +2230,8 @@ port map(
 		mondat	=>subdat,
 
 		EMUINITDONE		=>EMUINITDONE,
-		EMUBUSY			=>pLed,
+		EMUBUSY			=>open,
+		FDCBUSY			=>pLed,
 		CPUCLK			=>SUBCLK,
 		clk21m			=>clk21m,
 		ramclk			=>rclk,

--- a/rtl/SUBunit/SUBunitsMiSTer.vhd
+++ b/rtl/SUBunit/SUBunitsMiSTer.vhd
@@ -72,6 +72,7 @@ port(
 	
 	EMUINITDONE		:out std_logic;
 	EMUBUSY			:out std_logic;
+	FDCBUSY			:out std_logic;
 	CPUCLK			:in std_logic;
 	clk21m			:in std_logic;
 	ramclk			:in std_logic;
@@ -926,5 +927,10 @@ port map(
 	MTS0 :MTsave generic map(sysclk,4000) port map(MON0S,EN0,'1',MON0,MTSAVEON,clk21m,rstn);
 	MTS1 :MTsave generic map(sysclk,4000) port map(MON1S,EN1,'1',MON1,MTSAVEON,clk21m,rstn);
 
+	process(clk21m)begin
+		if(clk21m' event and clk21m='1')then
+			FDCBUSY<=FDC_BUSY;
+		end if;
+	end process;
 
 end MAIN;


### PR DESCRIPTION
Disk LED and User LED were not working properly, so I changed the functionality.

- Disk LED - indicates access to the MiSTer system (loading/saving D88 images)
- User LED - acts as an alternative to the access indicator on FDD
