### PR TITLE
Fix CRTC attribute change limits

### DIFF
--- a/rtl/VIDEO/TRAMCONV.vhd
+++ b/rtl/VIDEO/TRAMCONV.vhd
@@ -301,7 +301,7 @@ begin
 				when ST_SETATR2 =>
 					if(CHARCNT<LINECHARS)then
 						CDSTADR<=CDSTADR+x"002";
-						if((fATTR(CHARCNT)='1') and (ATRCNT<iATTRLEN))then
+						if((fATTR(CHARCNT)='1') and (ATRCNT<iATTRLEN+1))then
 							STATE<=ST_RDATR2;
 						else
 							STATE<=ST_SETATR;


### PR DESCRIPTION
The CRTC supports up to 20 attribute changes, but only 19 were allowed.
Fixes upper limit check.