### PR TITLE
Change the aspect ratio in normal mode

### DIFF
--- a/PC8801SR.sv
+++ b/PC8801SR.sv
@@ -509,8 +509,8 @@ video_freak video_freak
 (
     .*,
     .VGA_DE_IN(vga_de),
-    .ARX((!ar) ? 12'd4 : (ar - 1'd1)),
-    .ARY((!ar) ? 12'd3 : 12'd0),
+    .ARX((!ar) ? 12'd16 : (ar - 1'd1)),
+    .ARY((!ar) ? 12'd10 : 12'd0),
     .CROP_SIZE(en400p ? 10'd400 : 10'd0),
     .CROP_OFF(0),
     .SCALE(status[4:3])


### PR DESCRIPTION
Actual PC8801 series "high resolution" 24kHz CRT monitors display images with a maximum of 640x400 square dots, just like the PC9801 series.
The correct aspect ratio is 16:10, and the current 4:3 does not display images correctly in normal mode. Change the definition of aspect ratio in PC8801.sv.

Note:
In 640x200 mode, the even lines in 400 line mode are simply hidden, so the aspect ratio remains the same.