### PR TITLE
Workarounds for disk subsystem

### DIFF
--- a/rtl/SUBunit/SUBunitsMiSTer.vhd
+++ b/rtl/SUBunit/SUBunitsMiSTer.vhd
@@ -624,6 +624,8 @@ signal	FDC_INDEXn	:std_logic;
 signal	FDC_SIDEn	:std_logic;
 signal	FDC_WPROTn	:std_logic;
 signal	FDC_MFM		:std_logic;
+signal	FDC_TWOSIDE	:std_logic;
+signal	FDC_READY	:std_logic;
 signal	FDE_EMUEN	:std_logic_vector(1 downto 0);
 signal	TDSEL		:std_logic;
 signal	RVSEL		:std_logic;
@@ -776,8 +778,8 @@ port map(
 	index	=>FDC_INDEXn,
 	side	=>FDC_SIDEn,
 	usel	=>FD_USEL,
-	READY	=>'0',	-- The actual chip is active high, but here it's active low.
-	TWOSIDE	=>not FDC_READYn,
+	READY	=>FDC_READY,	-- The actual chip is active high, but here it's active low.
+	TWOSIDE	=>FDC_TWOSIDE,
 	
 	int0	=>FD_int0,
 	int1	=>FD_int1,
@@ -798,6 +800,8 @@ port map(
 	fclk	=>clk21m,
 	rstn	=>CPUrstn
 );
+	FDC_READY<=		FD_USEL(1);
+	FDC_TWOSIDE<=	not FDC_READYn;
 
 	DSKE	:diskemu_mister generic map(
 		fclkfreq		=>sysclk,

--- a/rtl/diskemu_mister/FDemu.vhd
+++ b/rtl/diskemu_mister/FDemu.vhd
@@ -22,6 +22,7 @@ port(
 	wrote		:out std_logic_vector(3 downto 0);
 	wprot		:in std_logic_vector(3 downto 0);
 	tracklen	:out std_logic_vector(13 downto 0);
+	fdenable	:in std_logic_vector(3 downto 0);
 	
 	USEL	:in std_logic_vector(1 downto 0);
 	MOTOR	:in std_logic;
@@ -112,6 +113,14 @@ signal	fdmode1	:std_logic_vector(1 downto 0);
 signal	fdmode2	:std_logic_vector(1 downto 0);
 signal	fdmode3	:std_logic_vector(1 downto 0);
 signal	selfdmode:std_logic_vector(1 downto 0);
+
+signal	txenable	:std_logic;
+signal	fdenbl0		:std_logic;
+signal	fdenbl1		:std_logic;
+signal	fdenbl2		:std_logic;
+signal	fdenbl3		:std_logic;
+signal	l1fdenable	:std_logic_vector(3 downto 0);
+signal	l2fdenable	:std_logic_vector(3 downto 0);
 
 signal	rxwr	:std_logic;
 signal	GAPS	:integer	range 0 to 31;
@@ -302,7 +311,27 @@ begin
 			end if;
 		end if;
 	end process;
-	
+	process(clk,rstn)begin
+		if(rstn='0')then
+			fdenbl0<='0';
+			fdenbl1<='0';
+			fdenbl2<='0';
+			fdenbl3<='0';
+		elsif(clk' event and clk='1')then
+			l1fdenable<=fdenable;
+			case USEL is
+			when "00" =>
+				fdenbl0<=l1fdenable(0);
+			when "01" =>
+				fdenbl1<=l1fdenable(1);
+			when "10" =>
+				fdenbl2<=l1fdenable(2);
+			when "11" =>
+				fdenbl3<=l1fdenable(3);
+			when others =>
+			end case;
+		end if;	
+	end process;
 	
 	selfdmode<=	fdmode0	when USEL="00" else
 					fdmode1	when USEL="01" else
@@ -310,6 +339,11 @@ begin
 					fdmode3	when USEL="11" else
 					"00";
 	curfdmode<=fdmode3 & fdmode2 & fdmode1 & fdmode0;
+	txenable<= fdenbl0 when USEL="00" else
+					fdenbl1	when USEL="01" else
+					fdenbl2	when USEL="10" else
+					fdenbl3	when USEL="11" else
+					'0';
 
 	bitlenr<=	4000*sysclk/1000000	when selfdmode(1)='0' else 2000*sysclk/1000000;
 				
@@ -348,7 +382,7 @@ begin
 		elsif(clk' event and clk='1')then
 			txwr<='0';
 			if(MOTOR='1')then
-				if(WRENn='1' and txemp='1')then
+				if(WRENn='1' and txemp='1' and txenable='1')then
 					if(WRENn='1')then
 						txwr<='1';
 					end if;

--- a/rtl/diskemu_mister/diskemu_mister.vhd
+++ b/rtl/diskemu_mister/diskemu_mister.vhd
@@ -1331,6 +1331,9 @@ begin
 								trackwrdat<=x"0000";
 							end if;
 							fdstate<=fs_syncd;
+							if(sectlen=x"0000")then
+								sectlen<=x"0080";
+							end if;
 						end if;
 						trackwr<='1';
 						swait:=1;

--- a/rtl/diskemu_mister/diskemu_mister.vhd
+++ b/rtl/diskemu_mister/diskemu_mister.vhd
@@ -411,6 +411,7 @@ port(
 	wrote		:out std_logic_vector(3 downto 0);
 	wprot		:in std_logic_vector(3 downto 0);
 	tracklen	:out std_logic_vector(13 downto 0);
+	fdenable	:in std_logic_vector(3 downto 0);
 	
 	USEL	:in std_logic_vector(1 downto 0);
 	MOTOR	:in std_logic;
@@ -2072,6 +2073,7 @@ begin
 		-- wrote			=>fde_wrote,
 		wprot			=>"00" & wrprot,
 		tracklen		=>fde_tracklen,
+		fdenable		=>"00" & fdc_indiskb,
 		
 		USEL			=>fdc_usel,
 		MOTOR			=>fdc_motoren,
@@ -2093,11 +2095,11 @@ begin
 	fdc_track0n<=	fde_track0n when fdc_useln="10" else
 						fde_track0n when fdc_useln="01" else
 						'1';
-	fdc_indexn<=	fde_indexn	when fdc_motorn(0)='0' and fdc_indiskb(0)='1' and fdc_useln="10" else
-						fde_indexn	when  fdc_motorn(1)='0' and fdc_indiskb(1)='1' and fdc_useln="01" else
+	fdc_indexn<=	fde_indexn	when fdc_useln="10" else
+						fde_indexn	when fdc_useln="01" else
 						'1';
-	fdc_rdbitn<=	fde_rdbitn	when fdc_motorn(0)='0' and fdc_indiskb(0)='1' and fdc_useln="10" else
-						fde_rdbitn	when  fdc_motorn(1)='0' and fdc_indiskb(1)='1' and fdc_useln="01" else
+	fdc_rdbitn<=	fde_rdbitn	when fdc_useln="10" else
+						fde_rdbitn	when fdc_useln="01" else
 						'1';
 	
 	fdc_readyn<=fdc_motorn(0) when fdc_indiskb(0)='1' and fdc_useln(0)='0' else


### PR DESCRIPTION
Workaround for the issue caused by PR #59.
The non-existent third and fourth FDDs will appear as NOT READY.

In addition, a workaround for the issue where D88 image files with abnormal sector sizes are not extracted correctly also applies.