### PR TITLE
Fix V1S/N text attribute corruption from unsynchronised CDC in TRAMCONV

### DIFF
--- a/rtl/PC88MiSTer.vhd
+++ b/rtl/PC88MiSTer.vhd
@@ -1224,6 +1224,8 @@ signal	IDAT_INTC	:std_logic_vector(7 downto 0);
 signal	INTC_OE		:std_logic;
 signal	HRTC		:std_logic;
 signal	VRTC		:std_logic;
+signal	HRTCr		:std_logic;
+signal	VRTCr		:std_logic;
 signal	CDI			:std_logic;
 signal	CCK			:std_logic;
 signal	CSTB		:std_logic;
@@ -1565,7 +1567,17 @@ begin
 	
 
 
-	VRTCi<=not VRTC;
+	--HRTC/VRTC are combinational outputs of the rclk domain (synccont2.vhd), so TRAMCONV
+	--can latch a decoding glitch when it reads them from clk21m. Register them here
+	--first. The added latency is one rclk period.
+	process(rclk)begin
+		if(rclk' event and rclk='1')then
+			HRTCr<=HRTC;
+			VRTCr<=VRTC;
+		end if;
+	end process;
+	--Port 40h below keeps the raw VRTC; this path gains one rclk cycle of latency.
+	VRTCi<=not VRTCr;
 
 	INT0n<=not INT_COMRX;
 	INT1n<=VRTCi;
@@ -1857,8 +1869,8 @@ port map(
 	TVRAM_WDAT	=>TCNV_WDAT,
 	TVRAM_WR	=>TCNV_WE,
 	
-	VRET		=>VRTC,
-	HRET		=>HRTC,
+	VRET		=>VRTCr,
+	HRET		=>HRTCr,
 	-- DONE		=>TCNVDONE,
 	
 	clk			=>clk21m,

--- a/rtl/VIDEO/TRAMCONV.vhd
+++ b/rtl/VIDEO/TRAMCONV.vhd
@@ -87,6 +87,29 @@ signal	LINESKIP	:std_logic;
 signal	fATTR		:std_logic_vector(79 downto 0);
 signal	LINES		:integer range 0 to MAXLINES;
 
+--Bound the ST_GETBUS wait so BUSREQn cannot remain asserted indefinitely. Not applied
+--to the MRAM_WAIT waits, where an SDRAM read is already outstanding and cannot be
+--cancelled.
+constant STUCKMAX	:integer	:=511;
+signal	stuckcnt	:integer range 0 to STUCKMAX;
+
+--BUSACKn and MRAM_WAIT cross from the rclk domain into clk21m.
+--Sample the asynchronous inputs once before the FSM uses them.
+signal	MRAM_WAITr	:std_logic;
+signal	BUSACKnr	:std_logic;
+
+--Sample the remaining cross-domain inputs before use by the FSM.
+signal	VRETr,HRETr	:std_logic;
+signal	TEXTENr		:std_logic;
+
+--Keep the CDC sampling registers from being duplicated or retimed.
+attribute preserve : boolean;
+attribute dont_replicate : boolean;
+attribute dont_retime : boolean;
+attribute preserve of MRAM_WAITr, BUSACKnr, VRETr, HRETr, TEXTENr : signal is true;
+attribute dont_replicate of MRAM_WAITr, BUSACKnr, VRETr, HRETr, TEXTENr : signal is true;
+attribute dont_retime of MRAM_WAITr, BUSACKnr, VRETr, HRETr, TEXTENr : signal is true;
+
 begin
 
 	RDDAT<=MRAM_DAT when rTMODE='1' else TRAM_DAT;
@@ -127,15 +150,38 @@ begin
 			DONE<='0';
 			waitcount<=0;
 			LINESKIP<='0';
+			stuckcnt<=0;
+			MRAM_WAITr<='0';
+			BUSACKnr<='1';
+			VRETr<='1';
+			HRETr<='1';
+			TEXTENr<='0';
 		elsif(clk' event and clk='1')then
+			MRAM_WAITr<=MRAM_WAIT;
+			BUSACKnr<=BUSACKn;
+			VRETr<=VRET;
+			HRETr<=HRET;
+			TEXTENr<=TEXTEN;
 			TVRAM_WR<='0';
 			DONE<='0';
 			if(waitcount>0)then
 				waitcount<=waitcount-1;
 			else
+				--Only true in cycles where the state below does nothing, so the two
+				--assignments to STATE cannot collide.
+				if(STATE=ST_GETBUS and BUSACKnr='1')then
+					if(stuckcnt=STUCKMAX)then
+						stuckcnt<=0;
+						STATE<=ST_RELBUS;
+					else
+						stuckcnt<=stuckcnt+1;
+					end if;
+				else
+					stuckcnt<=0;
+				end if;
 				case STATE is
 				when ST_IDLE =>
-					if(lVRET='1' and VRET='0')then
+					if(lVRET='1' and VRETr='0')then
 						STXTADR<=TADR_TOP;
 						SATRADR<=TADR_TOP+x"0050";
 						SDSTADR<=(others=>'0');
@@ -150,7 +196,7 @@ begin
 						LINECNT<=0;
 						CURATR<="00000111";
 						LINESKIP<='0';
-					elsif(lHRET='1' and HRET='0' and TEXTEN='1')then
+					elsif(lHRET='1' and HRETr='0' and TEXTENr='1')then
 						CHARCNT<=0;
 						ATRCNT<=0;
 						if(LINECNT<MAXLINES)then
@@ -176,7 +222,7 @@ begin
 						end if;
 					end if;
 				when ST_GETBUS =>
-					if(BUSACKn='0')then
+					if(BUSACKnr='0')then
 						STATE<=ST_RDTXT;
 						BUS_USE<='1';
 					end if;
@@ -185,10 +231,11 @@ begin
 					RDADR<=CTXTADR;
 					STATE<=ST_RDTXT1;
 					if(rTMODE='1')then
-						waitcount<=2;
+						--One cycle more, to pay back the cycle spent registering MRAM_WAIT.
+						waitcount<=3;
 					end if;
 				when ST_RDTXT1 =>
-					if(rTMODE='0' or MRAM_WAIT='0')then
+					if(rTMODE='0' or MRAM_WAITr='0')then
 						MRAM_RDn<='1';
 						TVRAM_ADR<=CDSTADR;
 						if (LINESKIP='1')then
@@ -227,10 +274,11 @@ begin
 					RDADR<=CATRADR;
 					STATE<=ST_RDATR1;
 					if(rTMODE='1')then
-						waitcount<=2;
+						--One cycle more, to pay back the cycle spent registering MRAM_WAIT.
+						waitcount<=3;
 					end if;
 				when ST_RDATR1 =>
-					if(rTMODE='0' or MRAM_WAIT='0')then
+					if(rTMODE='0' or MRAM_WAITr='0')then
 						case(RDDAT(6 downto 4))is
 							when o"0"|o"1"|o"2"|o"3"|o"4" =>
 								iATTRCUL:=conv_integer(RDDAT);
@@ -258,10 +306,11 @@ begin
 					MRAM_RDn<='0';
 					STATE<=ST_RDATR3;
 					if(rTMODE='1')then
-						waitcount<=2;
+						--One cycle more, to pay back the cycle spent registering MRAM_WAIT.
+						waitcount<=3;
 					end if;
 				when ST_RDATR3 =>
-					if(rTMODE='0' or MRAM_WAIT='0')then
+					if(rTMODE='0' or MRAM_WAITr='0')then
 						if(COLOR='0' or ATTRCOLOR='0')then
 							CURATR(0)<='1';
 							CURATR(1)<='1';
@@ -331,8 +380,8 @@ begin
 				when others=>
 					STATE<=ST_RELBUS;
 				end case;
-				lVRET<=VRET;
-				lHRET<=HRET;
+				lVRET<=VRETr;
+				lHRET<=HRETr;
 			end if;
 		end if;
 	end process;


### PR DESCRIPTION
## Symptom

In V1S and N, text attributes can flicker or become corrupted.

The problem depends on the fitter seed. Of eight seeds I tested, three showed the
corruption. The released `.rbf` does not show it, which may be why it has gone unnoticed.

To see it: boot with Mode = N88V1S and Disk boot = Disable, and look at the character
attributes on the `How many files(0-15)?` screen.


Before and after, seed 7, same board:

![77f2bfe, seed 7](https://raw.githubusercontent.com/okuyam2y/PC88_MiSTer/evidence/v1s-upstream-77f2bfe-seed7-broken.png)

![this branch, seed 7](https://raw.githubusercontent.com/okuyam2y/PC88_MiSTer/evidence/v1s-with-fix-seed7-clean.png)

## Cause

`TRAMCONV` runs on `clk21m` (20 MHz), but waits on two signals from the `rclk` (75 MHz)
domain without synchronising them first: `MRAM_WAIT` and `BUSACKn`. It also uses
`HRET`/`VRET`, which `synccont2.vhd` produces as combinational compares of
`VCOUNT`/`HUCOUNT`.

This can make `TRAMCONV` latch an intermediate value of those compares, corrupting
attributes when `TMODE` is active (V1S and N). It can also leave the bits of `STATE`
holding different values, so `STATE` lands on a value no normal transition produces.

These waits hold `BUSREQn` while stalled. I saw a bus hang once on my own build, but
could not reproduce it on an unmodified upstream build, so I am not treating the hang as
a reproduced upstream bug.

## Changes

* Register `HRTC`/`VRTC` on `rclk` in `PC88MiSTer.vhd`, and synchronise the crossing
  signals in `TRAMCONV` before the FSM uses them, so every bit of `STATE` sees the same
  sample. Port 40h still reads the raw `VRTC`. The vertical retrace interrupt uses the
  registered copy, adding one `rclk` cycle of latency.
* The three SDRAM read waits go from 3 to 4 cycles, to pay back the cycle spent
  registering `MRAM_WAIT`. It is examined at the same point after the request as before.
* Add a timeout to the wait for the bus in `ST_GETBUS`. Not to the `MRAM_WAIT` waits: an
  SDRAM read is already outstanding there and the controller cannot cancel it, so giving
  up could let the abandoned transfer clear the Z80's wait. Nothing is outstanding in
  `ST_GETBUS`.

On timeout, the request is dropped and that scan line is abandoned. Processing retries on
the next line. The display may remain disturbed until the next `VRET`.

The sampling registers carry `preserve`, `dont_replicate` and `dont_retime`, since the
project enables register duplication and retiming globally.

## Testing

I built eight fitter seeds from `77f2bfe` and from this branch, with Quartus 17.0.2 Build
602, the version named in `PC88.qsf`. Placement decides whether the defect appears, so a
different Quartus version may not fail on the same seed.

|             |         1 |  2 |          3 |  4 |  5 |  6 |          7 |  8 |
| ----------- | --------: | -: | ---------: | -: | -: | -: | ---------: | -: |
| `77f2bfe`   | **9,019** | 32 | **22,418** | 32 | 32 | 32 | **21,151** | 32 |
| this branch |        32 | 32 |         32 | 32 | 32 | 32 |         32 | 32 |

Figures are pixels differing between screenshots of the same build, taken a second apart.
32 over 4 rows is the blinking cursor. Pass/fail is checked by script because the
corruption flickers and a single frame can appear normal. Screenshots are taken using the
MiSTer's own `screenshot` command over SSH.

For the upstream revision, I only tested V1S at 4 MHz, which was enough to reproduce the
problem. Seeds 1 to 3 of this branch were also checked in V1S 8 MHz, V1H and V2, and are
clean.

Testing was done on one MiSTer and one Quartus version.

The timeout path can be tested for correct recovery, but I do not have a reliable way to
trigger the hang that motivated it. If the timeout is considered unnecessary, that commit
can be dropped.
